### PR TITLE
Update Cocoapods spec

### DIFF
--- a/PushyRN.podspec
+++ b/PushyRN.podspec
@@ -1,12 +1,15 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
 Pod::Spec.new do |s|
   s.name            = 'PushyRN'
-  s.version         = '1.0.8'
-  s.summary         = 'The official Pushy SDK for React Native iOS apps.'
-  s.description     = 'Pushy is the most reliable push notification gateway, perfect for real-time, mission-critical applications.'
-  s.homepage          = 'https://pushy.me/'
+  s.version         = package['version']
+  s.summary         = package['description']
+  s.homepage        = package['homepage']
 
-  s.author          = { 'Pushy' => 'contact@pushy.me' }
-  s.license         = { :type => 'Apache-2.0', :file => 'LICENSE' }
+  s.author          = package['author']
+  s.license         = package['license']
 
   s.platform        = :ios
   s.source          = { :git => 'https://github.com/pushy-me/pushy-react-native.git', :tag => s.version }

--- a/PushyRN.podspec
+++ b/PushyRN.podspec
@@ -1,16 +1,16 @@
 Pod::Spec.new do |s|
   s.name            = 'PushyRN'
-  s.version         = '1.0.2'
+  s.version         = '1.0.8'
   s.summary         = 'The official Pushy SDK for React Native iOS apps.'
   s.description     = 'Pushy is the most reliable push notification gateway, perfect for real-time, mission-critical applications.'
   s.homepage          = 'https://pushy.me/'
-  
+
   s.author          = { 'Pushy' => 'contact@pushy.me' }
   s.license         = { :type => 'Apache-2.0', :file => 'LICENSE' }
 
   s.platform        = :ios
   s.source          = { :git => 'https://github.com/pushy-me/pushy-react-native.git', :tag => s.version }
-  s.source_files    = 'PushyRN/**/*.{h,m,swift}'
+  s.source_files    = '**/*.{h,m,swift}'
   s.requires_arc    = true
 
   s.dependency 'React'


### PR DESCRIPTION
Lots of things changed after opening #16 
New React Native version defaults to cocoa pods now. So making some changes on podspec. All of the changes are inspired from react native community projects. 

- Moves the pod spec file to the root directory (Pods standard way)
- Updates the pod spec to get the details from `package.json`